### PR TITLE
Add settings for login triggers.

### DIFF
--- a/admin/options.php
+++ b/admin/options.php
@@ -69,6 +69,32 @@ function page_init() {
 	);
 
 	/*
+	 * Login trigger settings.
+	 */
+	add_settings_section(
+		'web3wp_login_section', // id.
+		__( 'Login Settings', 'web3wp' ), // title.
+		null, // callback.
+		'web3wp-admin' // page.
+	);
+
+	add_settings_field(
+		'login_trigger_class',
+		__( 'CSS trigger class', 'web3wp' ),
+		__NAMESPACE__ . '\login_trigger_class_callback',
+		'web3wp-admin',
+		'web3wp_login_section'
+	);
+
+	add_settings_field(
+		'login_trigger_auto',
+		__( 'Connect wallet on load', 'web3wp' ),
+		__NAMESPACE__ . '\login_trigger_auto_callback',
+		'web3wp-admin',
+		'web3wp_login_section'
+	);
+
+	/*
 	 * E-mail and Password settings.
 	 */
 	add_settings_section(
@@ -104,6 +130,9 @@ function page_init() {
 function sanitize( $input ) {
 	$sanitary_values = array();
 
+	$sanitary_values['login_trigger_class']   = isset( $input['login_trigger_class'] ) && ! empty( $input['login_trigger_class'] ) ? sanitize_text_field( wp_unslash( $input['login_trigger_class'] ) ) : 'connect-wallet-link';
+	$sanitary_values['login_trigger_auto'] = falsey_truthy( 'login_trigger_auto', $input );
+
 	$sanitary_values['disable_password_fields']       = falsey_truthy( 'disable_password_fields', $input );
 	$sanitary_values['disable_application_passwords'] = falsey_truthy( 'disable_application_passwords', $input );
 
@@ -122,6 +151,33 @@ function falsey_truthy( $key, $input ) {
 		return 0;
 	}
 	return in_array( $input[ $key ], array( 'on', 'yes', 1, true ), true );
+}
+
+
+/**
+ * Render field.
+ *
+ * @return void
+ */
+function login_trigger_class_callback() {
+	$plugin_options = get_plugin_options();
+	printf(
+		'<input type="text" name="%s[login_trigger_class]" id="login_trigger_class" value="%s" placeholder="%s"><br><span class="description">%s</span>',
+		esc_attr( PLUGIN_OPTIONS_KEY ),
+		isset( $plugin_options['login_trigger_class'] ) ? esc_attr( $plugin_options['login_trigger_class'] ) : '',
+		esc_attr( 'connect-wallet-link' ),
+		esc_html__( 'CSS class that will trigger wallet connect.', 'web3wp' )
+	);
+}
+
+function login_trigger_auto_callback() {
+	$plugin_options = get_plugin_options();
+	printf(
+		'<input type="checkbox" name="%s[login_trigger_auto]" id="login_trigger_auto" %s><span class="description">%s</span>',
+		esc_attr( PLUGIN_OPTIONS_KEY ),
+		checked( 1, isset( $plugin_options['login_trigger_auto'] ) ? (bool) $plugin_options['login_trigger_auto'] : false, false ),
+		esc_html__( 'Trigger immediately when a user visits.', 'web3wp' )
+	);
 }
 
 /**

--- a/assets/connect.js
+++ b/assets/connect.js
@@ -91,6 +91,19 @@ const attach_events = async (params) => {
             location.reload()
         }
     })
+
+    // Get login trigger.
+    const cssTrigger = params.walletCssTrigger
+    if ( cssTrigger ) {
+        document.querySelectorAll(`.${cssTrigger}`).forEach(function(el){ 
+            el.addEventListener('click', async () => {
+                if (params.nonce && params.user.ID === 0) {
+                    // Login by signing the nonce.
+                    await loginBySigning(params.connectedWallet, params.signingMessage, params.nonce, params.loginUrl);
+                }
+            })
+        })
+    }
 }
 
 const init = async () => {
@@ -101,18 +114,20 @@ const init = async () => {
             return
         }
 
-        const { nonce, user, signingMessage, baseUrl } = web3wp_connect        
+        const { nonce, user, signingMessage, baseUrl, autoConnectWallet } = web3wp_connect        
         const loginUrl = `${baseUrl}login`;
         const logoutUrl = `${baseUrl}logout`;
 
         await attach_events({ 
             logoutUrl,
             loginUrl,
-            nonce,
+            ...web3wp_connect,
+            connectedWallet, 
+            signingMessage,
         });
 
         // If the user is not logged in, attempt a login.
-        if (nonce && user.ID === 0) {
+        if (nonce && user.ID === 0 && autoConnectWallet) {
             // Login by signing the nonce.
             await loginBySigning(connectedWallet, signingMessage, nonce, loginUrl);
         }

--- a/assets/connect.js
+++ b/assets/connect.js
@@ -64,7 +64,7 @@ const loginBySigning = async (walletAddress, signingMessage, nonce, loginUrl) =>
             'X-Signed-Message': signedMessage,
         }
     });
-
+    
     if (response.ok) { // if HTTP-status is 200-299
         const json = await response.json()
         if (json.user) { location.reload(); }
@@ -78,31 +78,28 @@ const attach_events = async (params) => {
     // Changing wallet.
     window.ethereum.on('accountsChanged', async (accounts) => {
         const { logoutUrl, nonce } = params;
-        let response = await fetch(logoutUrl, {
+
+        // This logs the user out, but does not refresh the page.
+        await fetch(logoutUrl, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json;charset=utf-8',
                 'X-WP-Nonce': nonce,
             }
         });
-
-        if (response.ok) { // if HTTP-status is 200-299
-            const json = await response.json()
-            location.reload()
-        }
     })
 
     // Get login trigger.
     const cssTrigger = params.walletCssTrigger
     if (cssTrigger) {
-        document.querySelectorAll(`.${cssTrigger}`).forEach(function (el) {
+        document.querySelectorAll(`.${cssTrigger}`).forEach((el) => {
             el.addEventListener('click', async () => {
 
                 const connectedWallet = await getWalletConnection()
                 if (connectedWallet) {
                     if (params.nonce && params.user.ID === 0) {
                         // Login by signing the nonce.
-                        await loginBySigning(params.connectedWallet, params.signingMessage, params.nonce, params.loginUrl);
+                        await loginBySigning(connectedWallet, params.signingMessage, params.nonce, params.loginUrl);
                     }
                 }
             })

--- a/inc/hooks.php
+++ b/inc/hooks.php
@@ -25,6 +25,9 @@ if ( $options['disable_application_passwords'] ) {
  * @return void
  */
 function enqueue_scripts() {
+
+	$options = \Web3WP\get_plugin_options();
+
 	// Wallet connect features.
 	wp_enqueue_script( 'ethers-js', plugins_url() . '/web3wp-plugin/assets/ethers-5.1.umd.min.js', array(), '20211130', true );
 	wp_enqueue_script( 'web3wp-js', plugins_url() . '/web3wp-plugin/assets/connect.js', array( 'ethers-js' ), '20211130', true );
@@ -50,10 +53,12 @@ function enqueue_scripts() {
 	// translators: Place the nonce where required.
 	$signing_message     = sprintf( __( "Click 'Sign' to sign in with one time sign-in code: %s", 'web3wp' ), $nonce );
 	$web3wp_connect_vars = array(
-		'nonce'          => $nonce,
-		'signingMessage' => apply_filters( 'web3wp_signing_message', $signing_message, $nonce ),
-		'baseUrl'        => rest_url( 'web3wp/' ),
-		'user'           => $current_user,
+		'nonce'             => $nonce,
+		'signingMessage'    => apply_filters( 'web3wp_signing_message', $signing_message, $nonce ),
+		'baseUrl'           => rest_url( 'web3wp/' ),
+		'user'              => $current_user,
+		'walletCssTrigger'  => isset( $options['login_trigger_class'] ) ? esc_attr( $options['login_trigger_class'] ) : 'connect-wallet-link',
+		'autoConnectWallet' => isset( $options['login_trigger_auto'] ) && $options['login_trigger_auto'],
 	);
 	wp_add_inline_script( 'web3wp-js', 'const web3wp_connect = ' . wp_json_encode( $web3wp_connect_vars ) );
 }


### PR DESCRIPTION
Resolves #1 

1. Adds a new setting in 'Web3 WP' options to specify a CSS class that will trigger the wallet to connect.  Default: `connect-wallet-link`.

To test create a new element on the page (e.g. a menu item) and apply the desired CSS class to the element. Ensure that the element is set in the plugin options.

2. Adds a new setting that will force a wallet connect on page load (current behaviour) or to keep it disabled.